### PR TITLE
[WIP][src] add kenlm support into Kaldi

### DIFF
--- a/src/lm/kenlm-fst.h
+++ b/src/lm/kenlm-fst.h
@@ -1,0 +1,95 @@
+#ifndef KALDI_LM_KENLM_FST_H_
+#define KALDI_LM_KENLM_FST_H_
+
+#include <base/kaldi-common.h>
+#include <fst/fstlib.h>
+#include <fst/fst-decl.h>
+#include <fstext/deterministic-fst.h>
+#include "lm/kenlm.h"
+
+namespace kaldi {
+/*
+  This class wraps KenLM into Kaldi's DeterministicOnDemandFst class,
+  so that Kaldi toolkit can now use KenLM as a simple FST language model,
+  typical use cases are:
+    * big lm decoding
+    * lattice rescoring
+    * language model shallow fusion(online lm interpolation)
+  It serves a very similar role of Kaldi's CARPA,
+  with faster query speed and lower memory footprint.
+*/
+
+template<class Arc>
+class KenLmFst : public fst::DeterministicOnDemandFst<Arc> {
+ public:
+  typedef typename Arc::Weight Weight;
+  typedef typename Arc::StateId StateId;
+  typedef typename Arc::Label Label;
+  typedef typename KenLm::State State;
+  typedef typename KenLm::WordIndex WordIndex;
+ 
+  explicit KenLmFst(KenLm *lm)
+   : lm_(lm), num_states_(0), bos_state_id_(0)
+  {
+    MapElem elem;
+    lm->SetStateToBos(&elem.first);
+    elem.second = num_states_;
+
+    std::pair<IterType, bool> ins_result = state_map_.insert(elem);
+    KALDI_ASSERT(ins_result.second == true);
+    state_vec_.push_back(&ins_result.first->first);
+    num_states_++;
+
+    eos_symbol_id_ = lm_->GetSymbolIndex("</s>");
+  }
+  virtual ~KenLmFst() { }
+
+  virtual StateId Start() { 
+    return bos_state_id_;
+  }
+
+  virtual bool GetArc(StateId s, Label label, Arc *oarc) {
+    KALDI_ASSERT(s < static_cast<StateId>(state_vec_.size()));
+    const State* istate = state_vec_[s];
+    MapElem e;
+    WordIndex word = lm_->GetWordIndex(label);
+    BaseFloat log_10_prob = lm_->Score(istate, word, &e.first);
+    e.second = num_states_;
+    std::pair<IterType, bool> result = state_map_.insert(e);
+    if (result.second == true) {
+      state_vec_.push_back(&(result.first->first));
+      num_states_++;
+    }
+
+    oarc->ilabel = label;
+    oarc->olabel = oarc->ilabel;
+    oarc->nextstate = result.first->second;
+    oarc->weight = Weight(-log_10_prob * M_LN10); // KenLM's log10() -> Kaldi's ln()
+
+    return true;
+  }
+
+  virtual Weight Final(StateId s) {
+    Arc oarc;
+    GetArc(s, eos_symbol_id_, &oarc);
+    return oarc.weight;
+  }
+
+ private:
+  KenLm *lm_; // no ownership
+
+ private:
+  typedef std::pair<State, StateId> MapElem;
+  typedef unordered_map<State, StateId, KenLm::StateHasher> MapType; // use KenLM's MurMurHash as hash function
+  typedef typename MapType::iterator IterType;
+
+  MapType state_map_;
+  std::vector<const State*> state_vec_;
+  StateId num_states_; // state vector index range, [0, num_states_)
+
+  StateId bos_state_id_;  // fst start state id
+  WordIndex eos_symbol_id_;
+
+}; // class KenLmFst
+
+} // namespace kaldi

--- a/src/lm/kenlm-test.cc
+++ b/src/lm/kenlm-test.cc
@@ -1,0 +1,41 @@
+#include "util/text-utils.h"
+#include "util/kaldi-io.h"
+#include "lm/kenlm.h"
+
+namespace kaldi {
+
+void UnitTestKenLm() {
+  KenLm lm;
+  lm.Load("test_data/lm.kenlm", "test_data/words.txt");
+  lm.WriteReindex("test_data/reindex.txt");
+
+  std::ifstream is("test_data/sentences.txt");
+  std::string sentence;
+  while(std::getline(is, sentence)) {
+    std::vector<std::string> words;
+    SplitStringToVector(sentence, " ", true, &words);
+
+    KenLm::State state[2];
+    KenLm::State* istate = &state[0];
+    KenLm::State* ostate = &state[1];
+
+    lm.SetStateToBos(istate);
+    
+    std::string sentence_log;
+    for (int i = 0; i < words.size(); i++) {
+      std::string word = words[i];
+      BaseFloat word_score = lm.Score(istate, lm.GetWordIndex(word), ostate);
+      sentence_log += " " + word + ":" + std::to_string(lm.GetWordIndex(word)) + ":" + std::to_string(word_score);
+      std::swap(istate, ostate);
+    }
+    KALDI_LOG << sentence_log;
+  }
+}
+
+} // namespace kaldi
+
+int main(int argc, char *argv[]) {
+  using namespace kaldi;
+  UnitTestKenLm();
+  return 0;
+}

--- a/src/lm/kenlm.cc
+++ b/src/lm/kenlm.cc
@@ -1,0 +1,53 @@
+#include "lm/kenlm.h"
+
+namespace kaldi {
+
+int KenLm::Load(std::string kenlm_filename, std::string symbol_table_filename) {
+  DELETE(model_);
+  vocab_ = NULL;
+
+  // load KenLm model
+  lm::ngram::Config config;
+  config.load_method = util::LoadMethod::LAZY;
+  model_ = lm::ngram::LoadVirtual(kenlm_filename.c_str(), config);
+  if (!model_) {
+    KALDI_ERR << "Failed loading KenLm model";
+  }
+
+  // load vocab
+  vocab_ = &model_->BaseVocabulary();
+  if (!vocab_) {
+    KALDI_ERR << "Failed loading KenLm vocabulary";
+  }
+
+  // count symbol table size
+  int num_syms = 0;
+  std::string line;
+  {
+    std::ifstream is(symbol_table_filename);
+    while(std::getline(is, line)) { if (!line.empty()) num_syms++; }
+  }
+
+  // compute the word reindex from Kaldi symbol id to KenLm word id
+  reindex_.clear();
+  reindex_.resize(num_syms, 0); // 0 is always <unk> in KenLm
+
+  std::ifstream is(symbol_table_filename);
+  while (std::getline(is, line)) {
+    std::vector<std::string> fields;
+    SplitStringToVector(line, " ", true, &fields);
+    if (fields.size() == 2) {
+      std::string symbol = fields[0];
+      uint32 symbol_id = -1;
+      ConvertStringToInteger(fields[1], &symbol_id);
+      reindex_[symbol_id] = vocab_->Index(symbol.c_str());
+      symbol_to_symbol_id_[symbol] = symbol_id;
+    }
+  }
+
+  KALDI_LOG << "Kaldi word symble table size: " << reindex_.size();
+
+  return 0;
+}
+
+} // namespace kaldi

--- a/src/lm/kenlm.h
+++ b/src/lm/kenlm.h
@@ -1,0 +1,62 @@
+#ifndef KALDI_LM_KENLM_H
+#define KALDI_LM_KENLM_H
+
+#include "lm/model.hh"
+#include "util/murmur_hash.hh"
+
+namespace kaldi {
+
+class KenLm {
+ public:
+  typedef lm::WordIndex WordIndex;
+  typedef lm::ngram::State State;
+
+ public:
+  KenLm() : model_(NULL), vocab_(NULL) { }
+
+  ~KenLm() {
+    DELETE(model_);
+    vocab_ = NULL;
+    reindex_.clear();
+  }
+
+  int Load(std::string kenlm_filename, std::string symbol_table_filename);
+
+  inline int32 GetSymbolIndex(std::string symbol) { return symbol_to_symbol_id_[symbol]; }
+  inline WordIndex GetWordIndex(std::string word) { return vocab_->Index(word.c_str()); }
+  inline WordIndex GetWordIndex(int32 symbol_id) { return reindex_[symbol_id]; }
+
+  void SetStateToBos(State *s) { model_->BeginSentenceWrite(s); }
+  void SetStateToNull(State *s) { model_->NullContextWrite(s); }
+
+  inline BaseFloat Score(const State *istate, WordIndex word, State *ostate) {
+    return model_->BaseScore(istate, word, ostate);
+  }
+
+  struct StateHasher {
+    inline size_t operator()(const State &s) const noexcept {
+      return util::MurmurHashNative(s.words, sizeof(WordIndex) * s.Length());
+    }
+  };
+  
+ private:
+  lm::base::Model *model_;
+  const lm::base::Vocabulary* vocab_; // no ownership, it points to models_'s internal vocabuary
+  std::unordered_map<std::string, int32> symbol_to_symbol_id_;
+
+  // There are really two indexing systems here:
+  // Kaldi's fst output symbol id(defined in words.txt),
+  // and KenLM's word index(obtained by hashing the word string).
+  // in order to incorperate KenLM into Kaldi,
+  // we need to know the mapping between (Kaldi's symbol id -> KenLM's word id)
+  // special symbols:
+  // Kaldi's output symbol table contains two special symbols(<eps> and #0) that do not exist in KenLM,
+  // In any circumstance, these two symbols shouldn't consume any KenLM word,
+  // so the mapping of these two symbols are logically undefined,
+  // we just map them to KenLM's <unk>(which is always indexed as 0) to avoid random invalid mapping.
+  std::vector<WordIndex> reindex_; // reindex_[kaldi_symbol_index] -> kenlm word index
+}; // class KenLm
+
+} // namespace kaldi
+
+#endif


### PR DESCRIPTION
This PR adds kenlm support into Kaldi:

It is very similar to Kaldi's CARPA & OpenFST's G.fst(produced by arpa2fst), typical use cases are:
* decoding with super large LM (say biglm decoder or lookahead composition decoding)
* lattice rescoring with super large LM
* the KenLM FST wrapper can be used directly for LM online interpolation(or shallow fusion in nowadays fashion way)

The idea is simple: wrapping KenLM into Kaldi's *DeterministicOnDemandFst* interface, then Kaldi users don't need to know if the underlying LM is KenLM or CARPA or OpenFST, treat it as a simple FST. When we are dealing with super large ngram models, KenLM outperforms the other two in terms of both speed & memory.

I wrote these code a couple of months ago, it was kind of a rush.  And I've already tested it working correctly in another codebase. But to get this into official Kaldi, there are still some work to do such as configure, makefile, cleaner unit test, and demo script etc. 

@danpovey please have a quick look at this when you have time, if this is a desired enhancement, @naxingyu @chenguoguo 
 @jimbozhang said they can help with this feature.